### PR TITLE
Fix  Syntax Warning in regex

### DIFF
--- a/cscs-keygen.py
+++ b/cscs-keygen.py
@@ -34,7 +34,7 @@ def get_user_credentials():
     user = input("Username: ")
     pwd = getpass.getpass()
     otp = getpass.getpass("Enter OTP (6-digit code):")
-    if not (re.match('^\d{6}$', otp)):
+    if not (re.match('^\\d{6}$', otp)):
        sys.exit("Error: OTP must be a 6-digit code.")
     return user, pwd, otp
 


### PR DESCRIPTION
There was always this warning which comes in the more modern python version.
Adding a `/` should fix it.

```
cscs-keygen.py:37: SyntaxWarning: invalid escape sequence '\d'
```